### PR TITLE
changed extension to use full path to hocon config

### DIFF
--- a/src/Akka.Persistence.Cassandra/CassandraExtension.cs
+++ b/src/Akka.Persistence.Cassandra/CassandraExtension.cs
@@ -37,10 +37,10 @@ namespace Akka.Persistence.Cassandra
             SessionManager = CassandraSession.Instance.Apply(system);
             
             // Read config
-            var journalConfig = system.Settings.Config.GetConfig("cassandra-journal");
+            var journalConfig = system.Settings.Config.GetConfig("akka.persistence.journal.cassandra-journal");
             JournalSettings = new CassandraJournalSettings(journalConfig);
 
-            var snapshotConfig = system.Settings.Config.GetConfig("cassandra-snapshot-store");
+            var snapshotConfig = system.Settings.Config.GetConfig("akka.persistence.snapshot-store.cassandra-snapshot-store");
             SnapshotStoreSettings = new CassandraSnapshotStoreSettings(snapshotConfig);
         }
     }

--- a/src/Akka.Persistence.Cassandra/SessionManagement/DefaultSessionManager.cs
+++ b/src/Akka.Persistence.Cassandra/SessionManagement/DefaultSessionManager.cs
@@ -20,7 +20,7 @@ namespace Akka.Persistence.Cassandra.SessionManagement
             if (system == null) throw new ArgumentNullException("system");
 
             // Read configuration sections
-            _sessionConfigs = system.Settings.Config.GetConfig("cassandra-sessions");
+            _sessionConfigs = system.Settings.Config.GetConfig("akka.persistence.cassandra-sessions");
 
             _sessionCache = new ConcurrentDictionary<string, Lazy<ISession>>();
         }


### PR DESCRIPTION
changed extension to use full path to hocon config.  Putting overrides on hocon in config file was not overriding defaults when putting the values under the journal and snapshot-store paths.

<![CDATA[
        akka 
        {  
            stdout-loglevel = DEBUG
            loglevel = DEBUG
          loggers = ["Akka.Logger.Serilog.SerilogLogger,Akka.Logger.Serilog"]
            persistence 
          {
            journal 
            {
              plugin = "akka.persistence.journal.cassandra-journal"
              cassandra-journal 
              {

```
            # Type name of the cassandra journal plugin
            class = "Akka.Persistence.Cassandra.Journal.CassandraJournal, Akka.Persistence.Cassandra"

            # The name (key) of the session to use when resolving an ISession instance. When using default session management,
            # this points at configuration under the "cassandra-sessions" section where the session's configuration is found.
            session-key = "default"

            # Whether or not to quote table and keyspace names when executing statements against Cassandra
            use-quoted-identifiers = false

            # The keyspace to be created/used by the journal
            keyspace = "teststate"

            # A string to be appended to the CREATE KEYSPACE statement after the WITH clause when the keyspace is 
            # automatically created. Use this to define options like replication strategy.
            keyspace-creation-options = "REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"

            # When true the journal will automatically try to create the keyspace if it doesn't already exist on start
            keyspace-autocreate = true

            # Name of the table to be created/used by the journal
            table = "messages"

            # A string to be appended to the CREATE TABLE statement after the WITH clause. Use this to define things
            # like gc_grace_seconds or one of the many other table options.
            table-creation-properties = ""

            # The approximate number of rows per partition to use. Cannot be changed after table creation.
            partition-size = 5000000

            # The maximum number of messages to retrieve in one request when replaying messages
            max-result-size = 50001

            # Consistency level for reads
            read-consistency = "Quorum"

            # Consistency level for writes
            write-consistency = "Quorum"
          } 
        } 

        snapshot-store 
        {
          plugin = "akka.persistence.snapshot-store.cassandra-snapshot-store"
          cassandra-snapshot-store 
          {

            # Type name of the cassandra snapshot store plugin
            class = "Akka.Persistence.Cassandra.Snapshot.CassandraSnapshotStore, Akka.Persistence.Cassandra"

            # The name (key) of the session to use when resolving an ISession instance. When using default session management,
            # this points at configuration under the "cassandra-sessions" section where the session's configuration is found.
            session-key = "default"

            # Whether or not to quote table and keyspace names when executing statements against Cassandra
            use-quoted-identifiers = false

            # The keyspace to be created/used by the snapshot store
            keyspace = "teststate"

            # A string to be appended to the CREATE KEYSPACE statement after the WITH clause when the keyspace is 
            # automatically created. Use this to define options like replication strategy.
            keyspace-creation-options = "REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"

            # When true the journal will automatically try to create the keyspace if it doesn't already exist on start
            keyspace-autocreate = true

            # Name of the table to be created/used by the snapshot store
            table = "snapshots"

            # A string to be appended to the CREATE TABLE statement after the WITH clause. Use this to define things
            # like gc_grace_seconds or one of the many other table options.
            table-creation-properties = ""

            # The maximum number of snapshot metadata instances to retrieve in a single request when trying to find a
            # snapshot that matches the criteria
            max-metadata-result-size = 10

            # Consistency level for reads
            read-consistency = "One"

            # Consistency level for writes
            write-consistency = "One"
          }
        }
      }

    }
  ]]>
```
